### PR TITLE
reference_kind should used 1 unsigned byte

### DIFF
--- a/const.py
+++ b/const.py
@@ -76,7 +76,7 @@ class NameAndType(Constant):
 
 class MethodHandle(Constant):
     def __init__(self, stream: Stream):
-        self.reference_kind = stream.read_u2()
+        self.reference_kind = stream.read_u1()
         self.reference_index = stream.read_u2()
 
 

--- a/instruction.py
+++ b/instruction.py
@@ -34,8 +34,8 @@ class Instruction(Object):
             align = stream.tell() % 4
             stream.read_bytes((4 - align) if align else 0)
             self.default = stream.read_u4()
-            self.low = stream.read_u4()
-            self.high = stream.read_u4()
+            self.low = stream.read_s4()
+            self.high = stream.read_s4()
             self.jump_offsets = [stream.read_u4() for _ in range(self.high - self.low + 1)]
             raise Exception('verify this')
         elif self.NAME == 'wide':

--- a/instruction.py
+++ b/instruction.py
@@ -42,7 +42,7 @@ class Instruction(Object):
             self.opcode = stream.read_u1()
             self.index = stream.read_u2()
             # noinspection PyUnresolvedReferences
-            if self.opcode == Ins.iinc.OPCODE:
+            if self.opcode == Ins.iinc[0].OPCODE:
                 self.const = stream.read_u2()
         elif self.OPERANDS:
             for f in self.OPERANDS.split(', '):

--- a/stream.py
+++ b/stream.py
@@ -12,6 +12,8 @@ class Stream(object):
     def tell(self):
         return self.file.tell()
 
+    def read_s4(self) ->int:
+        return int.from_bytes(self.file.read(4), byteorder="big", signed=True)
     def read_u1(self) -> u1:
         return int.from_bytes(self.file.read(1), byteorder='big', signed=False)
 


### PR DESCRIPTION
CONSTANT_MethodHandle_info {
    u1 tag;
    u1 reference_kind;
    u2 reference_index;
}

ref it at https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html